### PR TITLE
feature/#13

### DIFF
--- a/RecommendRecipe/CategorySelectView/RecipeCardView/RecipeCardViewController.swift
+++ b/RecommendRecipe/CategorySelectView/RecipeCardView/RecipeCardViewController.swift
@@ -70,6 +70,8 @@ class RecipeCardViewController: UIViewController {
     
     func setBackgroundColor() {
         view.backgroundColor = UIColor(rgb: UIColor.baseColor)
+        undoButton.tintColor = UIColor.gray
+        addFavoriteButton.tintColor = UIColor.gray
     }
     
     func setButtonTarget() {
@@ -99,8 +101,6 @@ class RecipeCardViewController: UIViewController {
             undoButton.isEnabled = true
         }
     }
-    
-
     
     func updateCardCountLabel() {
         let currentCount = kolodaView.currentCardIndex + 1

--- a/RecommendRecipe/FavoriteView/FavoriteCollectionViewController.swift
+++ b/RecommendRecipe/FavoriteView/FavoriteCollectionViewController.swift
@@ -74,6 +74,7 @@ class FavoriteCollectionViewController: UICollectionViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         collectionView.isUserInteractionEnabled = true
+        collectionView.reloadData()
     }
     
     func setCellLayout() {

--- a/RecommendRecipe/FavoriteView/FavoriteTableView/FavoriteTableView.storyboard
+++ b/RecommendRecipe/FavoriteView/FavoriteTableView/FavoriteTableView.storyboard
@@ -3,7 +3,7 @@
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17156"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -12,17 +12,40 @@
         <scene sceneID="5pP-rm-a6U">
             <objects>
                 <tableViewController storyboardIdentifier="FavoriteTableView" useStoryboardIdentifierAsRestorationIdentifier="YES" id="cdY-tp-UNe" customClass="FavoriteTableViewController" customModule="RecommendRecipe" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="UUq-GC-xP4">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="UUq-GC-xP4">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="DKa-w4-oIo">
-                                <rect key="frame" x="0.0" y="28" width="414" height="43.5"/>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="favoriteCell" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="favoriteCell" rowHeight="44" id="DKa-w4-oIo">
+                                <rect key="frame" x="0.0" y="55.5" width="414" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="DKa-w4-oIo" id="9SI-SJ-OyN">
-                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                     <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" userInteractionEnabled="NO" tag="2" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="M85-EG-WQY">
+                                            <rect key="frame" x="112" y="11" width="267" height="22"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="11"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" tag="1" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Fs9-OL-5Cm">
+                                            <rect key="frame" x="35" y="0.0" width="62" height="44"/>
+                                        </imageView>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstAttribute="bottomMargin" secondItem="M85-EG-WQY" secondAttribute="bottom" id="Emt-la-5eu"/>
+                                        <constraint firstItem="M85-EG-WQY" firstAttribute="leading" secondItem="Fs9-OL-5Cm" secondAttribute="trailing" constant="15" id="F7Z-na-7Kr"/>
+                                        <constraint firstItem="M85-EG-WQY" firstAttribute="height" secondItem="9SI-SJ-OyN" secondAttribute="height" multiplier="0.5" id="L8D-Gg-GN8"/>
+                                        <constraint firstItem="Fs9-OL-5Cm" firstAttribute="centerY" secondItem="9SI-SJ-OyN" secondAttribute="centerY" id="Wal-zE-Zd6"/>
+                                        <constraint firstAttribute="trailingMargin" secondItem="M85-EG-WQY" secondAttribute="trailing" constant="15" id="Z62-Up-bes"/>
+                                        <constraint firstItem="Fs9-OL-5Cm" firstAttribute="leading" secondItem="9SI-SJ-OyN" secondAttribute="leadingMargin" constant="15" id="cal-sp-gNo"/>
+                                        <constraint firstItem="M85-EG-WQY" firstAttribute="centerY" secondItem="9SI-SJ-OyN" secondAttribute="centerY" id="oam-zK-byE"/>
+                                        <constraint firstItem="Fs9-OL-5Cm" firstAttribute="width" secondItem="9SI-SJ-OyN" secondAttribute="width" multiplier="0.15" id="tC7-7N-IoB"/>
+                                        <constraint firstItem="Fs9-OL-5Cm" firstAttribute="height" secondItem="9SI-SJ-OyN" secondAttribute="height" id="uGM-j8-8hB"/>
+                                        <constraint firstAttribute="bottom" secondItem="Fs9-OL-5Cm" secondAttribute="bottom" id="xwn-zt-oFM"/>
+                                    </constraints>
                                 </tableViewCellContentView>
                             </tableViewCell>
                         </prototypes>
@@ -34,7 +57,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Dgc-jp-LFN" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="103" y="125"/>
+            <point key="canvasLocation" x="102.89855072463769" y="124.55357142857142"/>
         </scene>
     </scenes>
     <resources>

--- a/RecommendRecipe/FavoriteView/FavoriteTableView/FavoriteTableViewController.swift
+++ b/RecommendRecipe/FavoriteView/FavoriteTableView/FavoriteTableViewController.swift
@@ -18,34 +18,36 @@ class FavoriteTableViewController: UITableViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        setNavigationItem()
+
+        if let title = navigationTitle {
+            setNavigationItem(title: title)
+        }
         setBackgroundColor()
-        
     }
     
     override func viewWillAppear(_ animated: Bool) {
         favoriteData = []
-        getFavoriteData()
+        if let categoryType = navigationTitle {
+            setFavoriteData(categoryType: categoryType)
+        }
         tableView.reloadData()
         view.isUserInteractionEnabled = true
     }
     
-    func setNavigationItem() {
-        if let title = navigationTitle {
-            navigationItem.title = title
-        }
+    func setNavigationItem(title: String) {
+        navigationItem.title = title
     }
     
     func setBackgroundColor() {
         view.backgroundColor = UIColor(rgb: UIColor.baseColor)
     }
 
-    func getFavoriteData() {
-        if let title = navigationTitle {
-            let object = RealmManager.shared.getObject(type: Favorite.self).filter("categoryType == %@",title).sorted(byKeyPath: "time", ascending: false)
-            for i in 0..<object.count{
-                favoriteData.append(object[i] as! Favorite)
+    func setFavoriteData(categoryType: String) {
+        let object = RealmManager.shared.getObject(type: Favorite.self).filter("categoryType == %@",categoryType).sorted(byKeyPath: "time", ascending: false)
+        
+        for i in 0..<object.count {
+            if let data = object[i] as? Favorite {
+                favoriteData.append(data)
             }
         }
     }

--- a/RecommendRecipe/FavoriteView/FavoriteTableView/FavoriteTableViewController.swift
+++ b/RecommendRecipe/FavoriteView/FavoriteTableView/FavoriteTableViewController.swift
@@ -7,86 +7,120 @@
 //
 
 import UIKit
+import RealmSwift
+
+private let reuseIdentifier = "favoriteCell"
 
 class FavoriteTableViewController: UITableViewController {
 
     var navigationTitle: String?
+    var favoriteData: Array<Favorite> = []
     
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Uncomment the following line to preserve selection between presentations
-        // self.clearsSelectionOnViewWillAppear = false
-
-        // Uncomment the following line to display an Edit button in the navigation bar for this view controller.
-        // self.navigationItem.rightBarButtonItem = self.editButtonItem
+        
+        setNavigationItem()
+        setBackgroundColor()
+        
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        favoriteData = []
+        getFavoriteData()
+        tableView.reloadData()
+        view.isUserInteractionEnabled = true
+    }
+    
+    func setNavigationItem() {
+        if let title = navigationTitle {
+            navigationItem.title = title
+        }
+    }
+    
+    func setBackgroundColor() {
+        view.backgroundColor = UIColor(rgb: UIColor.baseColor)
     }
 
+    func getFavoriteData() {
+        if let title = navigationTitle {
+            let object = RealmManager.shared.getObject(type: Favorite.self).filter("categoryType == %@",title).sorted(byKeyPath: "time", ascending: false)
+            for i in 0..<object.count{
+                favoriteData.append(object[i] as! Favorite)
+            }
+        }
+    }
+    
+    func setRecipeImage(cell: UITableViewCell, index: Int) {
+        let recipeImageTag = 1
+        let recipeImageView = cell.viewWithTag(recipeImageTag) as! UIImageView
+        recipeImageView.loadImageAsynchronously(url: URL(string: favoriteData[index].recipeImageUrl ),
+                                                defaultUIImage: nil)
+    }
+    
+    func setRecipeTitle(cell: UITableViewCell, index: Int) {
+        let recipeTitleLabelTag = 2
+        let recipeTitleLabel = cell.viewWithTag(recipeTitleLabelTag) as! UILabel
+        recipeTitleLabel.text = favoriteData[index].recipeTitle
+    }
+    
+    func addHistory(index: Int) {
+        guard !favoriteData.isEmpty else { return }
+                
+        let currentRecipeData = favoriteData[index]
+        let history = History()
+        
+        history.recipeId = currentRecipeData.recipeId
+        history.recipeTitle = currentRecipeData.recipeTitle
+        history.recipeImageUrl = currentRecipeData.recipeImageUrl
+        history.recipeUrl = currentRecipeData.recipeUrl
+        history.time = Date().getCurrentTime()
+        
+        RealmManager.shared.addDbData(object: history)
+    }
+    
+    func limitHistory() {
+        let historyLimit = 100
+        let historyData = RealmManager.shared.getObject(type: History.self).sorted(byKeyPath: "time", ascending: false)
+        guard let oldestHistory = historyData.last else { return }
+        
+        if (historyData.count > historyLimit) {
+            RealmManager.shared.deleteData(object: oldestHistory)
+        }
+    }
+    
     // MARK: - Table view data source
 
     override func numberOfSections(in tableView: UITableView) -> Int {
-        // #warning Incomplete implementation, return the number of sections
-        return 0
+        return 1
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        // #warning Incomplete implementation, return the number of rows
-        return 0
+        return favoriteData.count
     }
-
-    /*
+    
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "reuseIdentifier", for: indexPath)
-
-        // Configure the cell...
-
+        let cell = tableView.dequeueReusableCell(withIdentifier: reuseIdentifier, for: indexPath)
+        
+        setRecipeImage(cell: cell, index: indexPath.row)
+        setRecipeTitle(cell: cell, index: indexPath.row)
+        
         return cell
     }
-    */
+    
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        //DB保存
+        addHistory(index: indexPath.row)
+        limitHistory()
+        
+        //画面遷移
+        view.isUserInteractionEnabled = false
+        let nextViewController = UIStoryboard(name: "RecipeWebView", bundle: nil).instantiateViewController(withIdentifier: "RecipeWebView") as! RecipeWebViewController
 
-    /*
-    // Override to support conditional editing of the table view.
-    override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
-        // Return false if you do not want the specified item to be editable.
-        return true
+        let recipeUrl = favoriteData[indexPath.row].recipeUrl
+
+        nextViewController.urlString = recipeUrl
+        navigationController?.pushViewController(nextViewController, animated: true)
     }
-    */
 
-    /*
-    // Override to support editing the table view.
-    override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
-        if editingStyle == .delete {
-            // Delete the row from the data source
-            tableView.deleteRows(at: [indexPath], with: .fade)
-        } else if editingStyle == .insert {
-            // Create a new instance of the appropriate class, insert it into the array, and add a new row to the table view
-        }    
-    }
-    */
-
-    /*
-    // Override to support rearranging the table view.
-    override func tableView(_ tableView: UITableView, moveRowAt fromIndexPath: IndexPath, to: IndexPath) {
-
-    }
-    */
-
-    /*
-    // Override to support conditional rearranging of the table view.
-    override func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
-        // Return false if you do not want the item to be re-orderable.
-        return true
-    }
-    */
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
 
 }


### PR DESCRIPTION
## Issue
TableView作成(お気に入りリスト画面) #13

## 変更内容
・タイトル表示
・選択したカテゴリに区分されるレシピ名、画像、保存時間、URLをDBから取得。
・取得した文字と画像を保存時間の降順でcellに表示。
・cellタップでURLを渡してレシピ表示画面に遷移。
・タップ時に履歴DBにレシピ名、画像、URL、保存時間を保存。（重複可能で最大数１００）

## レビュー依頼内容
FavoriteTableViewController.swift内の以下の範囲
・44~51行　objectのキャストの方法がただしいか
・53~64行　storyboardのtagの使い方がただしいか